### PR TITLE
avrdude config file search path

### DIFF
--- a/cmake/modules/FindArduino.cmake
+++ b/cmake/modules/FindArduino.cmake
@@ -534,7 +534,7 @@ if(NOT ARDUINO_FOUND)
 
     find_program(ARDUINO_AVRDUDE_CONFIG_PATH
                  NAMES avrdude.conf
-                 PATHS ${ARDUINO_SDK_PATH}
+                 PATHS ${ARDUINO_SDK_PATH} /etc/avrdude
                  PATH_SUFFIXES hardware/tools
                                hardware/tools/avr/etc)
 


### PR DESCRIPTION
As I had avrdude installed by my distribution packages (Fedora), the config file was in /etc/avrdude. I simply added this folder to the avrdude.conf search path.
