### PR TITLE
Adding support for some SDK installation path

### DIFF
--- a/cmake/modules/FindArduino.cmake
+++ b/cmake/modules/FindArduino.cmake
@@ -46,10 +46,12 @@
 #    
 #       generate_arduino_library(test)
 
+file(GLOB SDK_PATHS /usr/share/arduino*)
 
 find_path(ARDUINO_SDK_PATH
           NAMES lib/version.txt hardware libraries
-          PATH_SUFFIXES  share/arduino
+		  PATH_SUFFIXES  share/arduino
+		  HINTS ${SDK_PATHS}
           DOC "Arduino Development Kit path.")
 
 


### PR DESCRIPTION
Hi,
Some distros (e.g. Gentoo) packages the Arduino SDK, and install it in (still for Gentoo) /usr/share/arduino-0022 (notice the -0022 at the end). Here's a little patch to search for arduino\* instead of just arduino (though still looking for specifics files and folders).
