### PR TITLE
Modifications 

### DIFF
--- a/cmake/modules/FindArduino.cmake
+++ b/cmake/modules/FindArduino.cmake
@@ -54,7 +54,6 @@ find_path(ARDUINO_SDK_PATH
 		  HINTS ${SDK_PATHS}
           DOC "Arduino Development Kit path.")
 
-
 # load_board_settings()
 #
 # Load the Arduino SDK board settings from the boards.txt file.
@@ -227,8 +226,10 @@ endfunction()
 #
 macro(setup_arduino_compiler BOARD_ID)
     set(BOARD_CORE ${${BOARD_ID}.build.core})
+    set(PIN_HEADER ${${BOARD_ID}.build.variant})
     if(BOARD_CORE)
         set(BOARD_CORE_PATH ${ARDUINO_CORES_PATH}/${BOARD_CORE})
+	include_directories(${ARDUINO_VARIANTS_PATH}/${PIN_HEADER})
         include_directories(${BOARD_CORE_PATH})
         include_directories(${ARDUINO_LIBRARIES_PATH})
         add_definitions(-DF_CPU=${${BOARD_ID}.build.f_cpu}
@@ -255,10 +256,8 @@ function(setup_arduino_core VAR_NAME BOARD_ID)
     if(BOARD_CORE AND NOT TARGET ${CORE_LIB_NAME})
         set(BOARD_CORE_PATH ${ARDUINO_CORES_PATH}/${BOARD_CORE})
         find_sources(CORE_SRCS ${BOARD_CORE_PATH} True)
-
         # Debian/Ubuntu fix
         list(REMOVE_ITEM CORE_SRCS "${BOARD_CORE_PATH}/main.cxx")
-
         add_library(${CORE_LIB_NAME} ${CORE_SRCS})
         set(${VAR_NAME} ${CORE_LIB_NAME} PARENT_SCOPE)
     endif()
@@ -444,7 +443,6 @@ endfunction()
 #
 function(setup_arduino_bootloader_upload TARGET_NAME BOARD_ID PORT)
     set(UPLOAD_TARGET ${TARGET_NAME}-upload)
-
     set(AVRDUDE_ARGS)
 
     setup_arduino_bootloader_args(${BOARD_ID} ${TARGET_NAME} ${PORT} AVRDUDE_ARGS)
@@ -455,7 +453,6 @@ function(setup_arduino_bootloader_upload TARGET_NAME BOARD_ID PORT)
     endif()
 
     list(APPEND AVRDUDE_ARGS "-Uflash:w:${TARGET_NAME}.hex")
-
     add_custom_target(${UPLOAD_TARGET}
                      ${ARDUINO_AVRDUDE_PROGRAM} 
                         ${AVRDUDE_ARGS}
@@ -878,6 +875,11 @@ if(NOT ARDUINO_FOUND)
               PATHS ${ARDUINO_SDK_PATH}
               PATH_SUFFIXES hardware/arduino)
 
+    find_file(ARDUINO_VARIANTS_PATH
+              NAMES variants 
+              PATHS ${ARDUINO_SDK_PATH}
+              PATH_SUFFIXES hardware/arduino)
+
     find_file(ARDUINO_BOOTLOADERS_PATH
               NAMES bootloaders
               PATHS ${ARDUINO_SDK_PATH}
@@ -936,6 +938,7 @@ if(NOT ARDUINO_FOUND)
 
 
      mark_as_advanced(ARDUINO_CORES_PATH
+		      ARDUINO_VARIANTS_PATH
                       ARDUINO_BOOTLOADERS_PATH
                       ARDUINO_SDK_VERSION
                       ARDUINO_LIBRARIES_PATH

--- a/cmake/toolchains/Arduino.cmake
+++ b/cmake/toolchains/Arduino.cmake
@@ -58,9 +58,11 @@ set(CMAKE_MODULE_LINKER_FLAGS_RELWITHDEBINFO ""                        CACHE STR
 
 
 set(ARDUINO_PATHS)
-foreach(VERSION RANGE 22 1)
-    list(APPEND ARDUINO_PATHS arduino-00${VERSION})
+foreach(VERSION 22 1)
+	list(APPEND ARDUINO_PATHS arduino-00${VERSION})
 endforeach()
+
+#list(APPEND ARDUINO_PATHS arduino)
 
 find_path(ARDUINO_SDK_PATH
           NAMES lib/version.txt

--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -12,11 +12,10 @@
 #====================================================================#
 set(FIRMWARE_NAME wire_reader)
 
-set(${FIRMWARE_NAME}_BOARD mega2560)               # Arduino Target board
+set(${FIRMWARE_NAME}_BOARD uno)               # Arduino Target board
 set(${FIRMWARE_NAME}_SRCS wire_master_reader.cpp)  # Firmware sources
 
-set(${FIRMWARE_NAME}_PORT /dev/ttyUSB0)            # Serial upload port
-set(${FIRMWARE_NAME}_SERIAL picocom @INPUT_PORT@ -b 9600 -l )  # Serial terminal cmd
+set(${FIRMWARE_NAME}_PORT /dev/ttyACM0)            # Serial upload port
 
 
 #====================================================================#

--- a/example/wire_master_reader.cpp
+++ b/example/wire_master_reader.cpp
@@ -9,8 +9,7 @@
 
 // This example code is in the public domain.
 
-
-#include <WProgram.h>
+#include <Arduino.h>
 #include <Wire.h>
 
 void setup()
@@ -25,7 +24,7 @@ void loop()
 
   while(Wire.available())    // slave may send less than requested
   { 
-    char c = Wire.receive(); // receive a byte as character
+    char c = Wire.read(); // receive a byte as character
     Serial.print(c);         // print the character
   }
 


### PR DESCRIPTION
- Modified wire_master_reader example to be compatible with changes to the wire library in 1.0
- Modifed FindArduino to use the correct pins_arduino.h file based on the defined board. Only added the directories to the build path, so it should remain back-compatible with older versions.

In addition :- Noted that it's printing out the board / programmer list regardless of whether it finds the path of the Arduino SDK, if the cache hasn't been built first. If it did find them, it successfully constructs the correct make file, however this is a little confusing.

Possibly update the documentation? it says to use 'make upload', but it seems like 'make {$target}-upload' is what is actually required to upload to the board.
