### PR TITLE
add RECURSE setting for SD library

### DIFF
--- a/cmake/modules/FindArduino.cmake
+++ b/cmake/modules/FindArduino.cmake
@@ -337,6 +337,7 @@ endfunction()
 # For known libraries can list recurse here
 set(Wire_RECURSE True)
 set(Ethernet_RECURSE True)
+set(SD_RECURSE True)
 function(setup_arduino_library VAR_NAME BOARD_ID LIB_PATH)
     set(LIB_TARGETS)
 


### PR DESCRIPTION
SD is part of the arduino installation and should be listed for recurse.
This is related to issue queezythegreat/arduino-cmake#22
