### PR TITLE
prefer the avrdude shipped by arduino sdk

### DIFF
--- a/cmake/modules/FindArduino.cmake
+++ b/cmake/modules/FindArduino.cmake
@@ -926,7 +926,10 @@ if(NOT ARDUINO_FOUND)
     find_program(ARDUINO_AVRDUDE_PROGRAM
                  NAMES avrdude
                  PATHS ${ARDUINO_SDK_PATH}
-                 PATH_SUFFIXES hardware/tools)
+                 PATH_SUFFIXES hardware/tools
+                 NO_DEFAULT_PATH)
+    find_program(ARDUINO_AVRDUDE_PROGRAM
+                 NAMES avrdude)
 
     find_program(ARDUINO_AVRDUDE_CONFIG_PATH
                  NAMES avrdude.conf


### PR DESCRIPTION
Since cmake prefers the systems paths instead of the given ones, the
avrdude installed by some Linux distributions might be prefered. Since
arduino patches the avrdude program, the default should be to use the
avrdude provided by the arduino sdk instead of the system one and only
use the later as a fallback option.

Of course, the user can still override the ARDUINO_AVRDUDE_PROGRAM
variable within cmake to use the systems binary.

This should be considered an RFC instead of a pull request. I experienced problems with the default avrdude on ubuntu und this might also be a problem when several arduino versions are installed and one of these installs it’s avrdude into the system’s binary path.

Also this might fix the problem described in issue queezythegreat/arduino-cmake#27 (at least the 2nd comment made me come up with this patch).
