### PR TITLE
Allow compilation in AVR only mode

### DIFF
--- a/example/CMakeLists.txt
+++ b/example/CMakeLists.txt
@@ -18,7 +18,7 @@ generate_arduino_example(Wire master_writer)
 # Original blink sketch (from Arduino SDK examples)
 #====================================================================#
 generate_arduino_firmware(blink_original
-    SKETCH ${ARDUINO_SDK_PATH}/examples/1.Basics/Blink
+    SKETCH ${ARDUINO_SDK_PATH}/examples/01.Basics/Blink
     PORT  /dev/ttyACM0
     BOARD uno)
 


### PR DESCRIPTION
This patch allows us to take advantage of the Arduino boot loader and of course CMake without allowing the code any dependency on Arduino libraries.

This option is very useful if you are using an Arduino board as a way to speed up development of programs designed to be as small as possible and compliant with the Atmel chip range outside of the Arduino environment.
