### PR TITLE
Added some features to support pure AVR (non-Arduino) usage

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -781,6 +781,7 @@ function(setup_arduino_target TARGET_NAME BOARD_ID ALL_SRCS ALL_LIBS COMPILE_FLA
     add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
                         COMMAND ${CMAKE_COMMAND}
                         ARGS    -DFIRMWARE_IMAGE=${TARGET_PATH}.hex
+                                -DEEPROM_IMAGE=${TARGET_PATH}.eep
                                 -P ${ARDUINO_SIZE_SCRIPT}
                         COMMENT "Calculating image size"
                         VERBATIM)
@@ -789,6 +790,7 @@ function(setup_arduino_target TARGET_NAME BOARD_ID ALL_SRCS ALL_LIBS COMPILE_FLA
     add_custom_target(${TARGET_NAME}-size
                         COMMAND ${CMAKE_COMMAND}
                                 -DFIRMWARE_IMAGE=${TARGET_PATH}.hex
+                                -DEEPROM_IMAGE=${TARGET_PATH}.eep
                                 -P ${ARDUINO_SIZE_SCRIPT}
                         DEPENDS ${TARGET_NAME}
                         COMMENT "Calculating ${TARGET_NAME} image size")
@@ -1527,19 +1529,11 @@ function(SETUP_ARDUINO_SIZE_SCRIPT OUTPUT_VAR)
     set(AVRSIZE_PROGRAM ${AVRSIZE_PROGRAM})
     set(AVRSIZE_FLAGS --target=ihex -d)
 
-    execute_process(COMMAND \${AVRSIZE_PROGRAM} \${AVRSIZE_FLAGS} \${FIRMWARE_IMAGE}
+    execute_process(COMMAND \${AVRSIZE_PROGRAM} \${AVRSIZE_FLAGS} \${FIRMWARE_IMAGE} \${EEPROM_IMAGE}
                     OUTPUT_VARIABLE SIZE_OUTPUT)
 
-    string(STRIP \"\${SIZE_OUTPUT}\" SIZE_OUTPUT)
-
-    # Convert lines into a list
-    string(REPLACE \"\\n\" \";\" SIZE_OUTPUT \"\${SIZE_OUTPUT}\")
-
-    list(GET SIZE_OUTPUT 1 SIZE_ROW)
-
-    if(SIZE_ROW MATCHES \"[ \\t]*[0-9]+[ \\t]*[0-9]+[ \\t]*[0-9]+[ \\t]*([0-9]+)[ \\t]*([0-9a-fA-F]+).*\")
-        message(\"Total size \${CMAKE_MATCH_1} bytes\")
-    endif()")
+    string( REGEX REPLACE \"/[^\\n]*/\" \"\" SIZE_OUTPUT \"\${SIZE_OUTPUT}\" )
+    message( \"\n\${SIZE_OUTPUT}\" )" )
 
     set(${OUTPUT_VAR} ${ARDUINO_SIZE_SCRIPT_PATH} PARENT_SCOPE)
 endfunction()

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -848,6 +848,7 @@ function(setup_arduino_bootloader_upload TARGET_NAME BOARD_ID PORT AVRDUDE_FLAGS
     endif()
 
     list(APPEND AVRDUDE_ARGS "-Uflash:w:${TARGET_NAME}.hex")
+    list(APPEND AVRDUDE_ARGS "-Ueeprom:w:${TARGET_NAME}.eep:i")
     add_custom_target(${UPLOAD_TARGET}
                      ${ARDUINO_AVRDUDE_PROGRAM} 
                      ${AVRDUDE_ARGS}

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -28,7 +28,7 @@
 #      PROGRAMMER     # Programmer id (enables programmer support)
 #      AFLAGS         # Avrdude flags for target
 #      NO_AUTOLIBS    # Disables Arduino library detection
-#      MANUAL     # (Advanced) Only use AVR Libc/Includes
+#      MANUAL         # (Advanced) Only use AVR Libc/Includes
 #
 # Here is a short example for a target named test:
 #    
@@ -55,7 +55,8 @@
 #      [SRCS  src1 src2 ... srcN]
 #      [HDRS  hdr1 hdr2 ... hdrN]
 #      [LIBS  lib1 lib2 ... libN]
-#      [NO_AUTOLIBS])
+#      [NO_AUTOLIBS]
+#      [MANUAL])
 #=============================================================================#
 #   generaters firmware and libraries for Arduino devices
 #
@@ -67,6 +68,7 @@
 #      HDRS           # Headers 
 #      LIBS           # Libraries to link
 #      NO_AUTOLIBS    # Disables Arduino library detection
+#      MANUAL         # (Advanced) Only use AVR Libc/Includes
 #
 # Here is a short example for a target named test:
 #    


### PR DESCRIPTION
Hi Tomasz,

First of all, thank you very much for arduino-cmake.  It is wonderful!

I end up doing more and more pure AVR (non-Arduino) coding.  Your toolset works great for doing this kind of work, simply using the NO_AUTOLIBS and MANUAL options.  It is better than any of the other AVR toolchains, especially as I can use a single toolchain to work in either Arduino or AVR mode.  

Still, I've worked it long enough that I wanted to recommend some changes to make this usage even easier and pass them for your consideration.  Please look at branch "igor" in my forked version of your repository.

There are 4 distinct, independent commits that do the following:

1 - Fix minor errors in the documentation that appears in the comments section of your code
2 - Changes the size reporting to report on both fimware and eeprom image sizes and provide the more detailed by section information
3 - Change the upload target so that it uploads both firmware and eeprom images
4 - Adds two new functions, generate_avr_firmware() and generate_avr_library() that work just like generate_arduino_XXX() except that you don't pass NO_AUTOLIBS or MANUAL -- these options are implied.  I coded these functions to just call the corresponding generate_arduino_XXX() functions appending the NO_AUTOLIBS and MANUAL arguments.

I'm not very experienced with CMake, so pehaps there are better ways to code the functions in patch 4.

Thanks for considering these changes.

Igor

igormt@alumni.caltech.edu
