### PR TITLE
Adds a basic support to add external platforms

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -1150,7 +1150,6 @@ function(setup_arduino_bootloader_args BOARD_ID TARGET_NAME PORT AVRDUDE_FLAGS O
         )  
 
     list(APPEND AVRDUDE_ARGS ${AVRDUDE_FLAGS})
-    message(STATUS "DEBUG: ARGS: ${AVRDUDE_ARGS}")
 
     set(${OUTPUT_VAR} ${AVRDUDE_ARGS} PARENT_SCOPE)
 endfunction()

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -619,7 +619,9 @@ function(get_arduino_flags COMPILE_FLAGS_VAR LINK_FLAGS_VAR BOARD_ID MANUAL)
         if(ARDUINO_SDK_VERSION VERSION_GREATER 1.0 OR ARDUINO_SDK_VERSION VERSION_EQUAL 1.0)
             if(NOT MANUAL)
                 set(PIN_HEADER ${${${BOARD_ID}.build.variant}.path})
-                set(COMPILE_FLAGS "${COMPILE_FLAGS} -I\"${PIN_HEADER}\"")
+                if(PIN_HEADER)
+                    set(COMPILE_FLAGS "${COMPILE_FLAGS} -I\"${PIN_HEADER}\"")
+                endif()
             endif()
         endif()
 
@@ -1130,19 +1132,25 @@ function(setup_arduino_bootloader_args BOARD_ID TARGET_NAME PORT AVRDUDE_FLAGS O
         )
 
     # Programmer
-    if(${BOARD_ID}.upload.protocol STREQUAL "stk500")
+    if(NOT ${BOARD_ID}.upload.protocol OR ${BOARD_ID}.upload.protocol STREQUAL "stk500")
         list(APPEND AVRDUDE_ARGS "-cstk500v1")
     else()
         list(APPEND AVRDUDE_ARGS "-c${${BOARD_ID}.upload.protocol}")
     endif()
 
+    set(UPLOAD_SPEED "19200")
+    if(${BOARD_ID}.upload.speed)
+        set(UPLOAD_SPEED ${${BOARD_ID}.upload.speed})
+    endif()
+
     list(APPEND AVRDUDE_ARGS
-        "-b${${BOARD_ID}.upload.speed}"     # Baud rate
+        "-b${UPLOAD_SPEED}"     # Baud rate
         "-P${PORT}"                         # Serial port
         "-D"                                # Dont erase
         )  
 
     list(APPEND AVRDUDE_ARGS ${AVRDUDE_FLAGS})
+    message(STATUS "DEBUG: ARGS: ${AVRDUDE_ARGS}")
 
     set(${OUTPUT_VAR} ${AVRDUDE_ARGS} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
fixes #41

Adds a new functions register_hardware_platform(). This functions takes
a path to the hardware platform such as
${ARDUINO_SDK_PATH}/hardware/${PLATFORM} and creates the varibles:

${PLATFORM}_CORES_PATH if cores exists
${PLATFORM}_BOARDS_PATH if boards.txt exists
${PLATFORM}_BOARDS if boards.txt exists
${PLATFORM}_PROGRAMMERS_PATH if programmers exists
${PLATFORM}_VARIENTS if varients exists

${PLATFORM} is the uppercase of the last directory name and so is
compatable with the previous variable names (ie hardware/arduino will
create ARDUINO_CORES_PATHS...)

Removes the now unused load boards and programmers methods for the
arduino platforms as this is now handeled by the new function.

Adds some new varibles;
  PLATFORMS lists all the registered platforms.
  VARIANTS  lists all the registared variants.
  ${variant}.path the path of the pins header file for the variant this
    is now used instead as the include path rather then
    ${ARDUINO_VARIANTS_PATH}/${variant}

Modifies the print boards and programmers to list all the platform
boards and programmers.
