### PR TITLE
Added ability for users to define a default serial target

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -447,7 +447,7 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
     message(STATUS "Generating ${INPUT_NAME}")
     parse_generator_arguments(${INPUT_NAME} INPUT
                               "NO_AUTOLIBS;MANUAL"                  # Options
-                              "BOARD;PORT;SKETCH;PROGRAMMER"        # One Value Keywords
+                              "BOARD;PORT;SKETCH;PROGRAMMER;DEFAULT_SERIAL"        # One Value Keywords
                               "SERIAL;SRCS;HDRS;LIBS;ARDLIBS;AFLAGS"  # Multi Value Keywords
                               ${ARGN})
 
@@ -515,6 +515,19 @@ function(GENERATE_ARDUINO_FIRMWARE INPUT_NAME)
         setup_serial_target(${INPUT_NAME} "${INPUT_SERIAL}" "${INPUT_PORT}")
     endif()
 
+    if(INPUT_DEFAULT_SERIAL)
+        if(NOT DECLARED_DEFAULT_SERIAL)
+            if(NOT TARGET serial)
+                set(DECLARED_DEFAULT_SERIAL "true")
+                setup_default_serial_target("${INPUT_SERIAL}" "${INPUT_PORT}")
+            else()
+                message(WARNING "A target named serial already exists, a default serial target will not be created for ${INPUT_NAME}")
+            endif()
+        else()
+            message(WARNING "A default serial target already exists, one will not be created for ${INPUT_NAME}")
+        endif()
+    endif()
+
 endfunction()
 
 #=============================================================================#
@@ -526,7 +539,7 @@ function(GENERATE_AVR_FIRMWARE INPUT_NAME)
     message(STATUS "Generating ${INPUT_NAME}")
     parse_generator_arguments(${INPUT_NAME} INPUT
                               "NO_AUTOLIBS;MANUAL"            # Options
-                              "BOARD;PORT;PROGRAMMER"  # One Value Keywords
+                              "BOARD;PORT;PROGRAMMER;DEFAULT_SERIAL"  # One Value Keywords
                               "SERIAL;SRCS;HDRS;LIBS;AFLAGS"  # Multi Value Keywords
                               ${ARGN})
  
@@ -562,6 +575,7 @@ function(GENERATE_AVR_FIRMWARE INPUT_NAME)
         PORT ${INPUT_PORT}
         PROGRAMMER ${INPUT_PROGRAMMER}
         SERIAL ${INPUT_SERIAL}
+        DEFAULT_SERIAL ${INPUT_DEFAULT_SERIAL}
         SRCS ${INPUT_SRCS}
         ${INPUT_HDRS}
         ${INPUT_LIBS}
@@ -576,7 +590,7 @@ endfunction()
 function(GENERATE_ARDUINO_EXAMPLE INPUT_NAME)
     parse_generator_arguments(${INPUT_NAME} INPUT
                               ""                                       # Options
-                              "LIBRARY;EXAMPLE;BOARD;PORT;PROGRAMMER"  # One Value Keywords
+                              "LIBRARY;EXAMPLE;BOARD;PORT;PROGRAMMER;DEFAULT_SERIAL"  # One Value Keywords
                               "SERIAL;AFLAGS"                          # Multi Value Keywords
                               ${ARGN})
 
@@ -628,6 +642,20 @@ function(GENERATE_ARDUINO_EXAMPLE INPUT_NAME)
     if(INPUT_SERIAL)
         setup_serial_target(${INPUT_NAME} "${INPUT_SERIAL}" "${INPUT_PORT}")
     endif()
+
+    if(INPUT_DEFAULT_SERIAL)
+        if(NOT DECLARED_DEFAULT_SERIAL)
+            if(NOT TARGET serial)
+                set(DECLARED_DEFAULT_SERIAL "true")
+                setup_default_serial_target("${INPUT_SERIAL}" "${INPUT_PORT}")
+            else()
+                message(WARNING "A target named serial already exists, a default serial target will not be created for ${INPUT_NAME}")
+            endif()
+        else()
+            message(WARNING "A default serial target already exists, one will not be created for ${INPUT_NAME}")
+        endif()
+    endif()
+
 endfunction()
 
 #=============================================================================#
@@ -1420,7 +1448,11 @@ function(setup_serial_target TARGET_NAME CMD SERIAL_PORT)
                       COMMAND ${FULL_CMD})
 endfunction()
 
-
+function(setup_default_serial_target CMD SERIAL_PORT)
+    string(CONFIGURE "${CMD}" FULL_CMD @ONLY)
+    add_custom_target(serial
+                      COMMAND ${FULL_CMD})
+endfunction()
 #=============================================================================#
 # [PRIVATE/INTERNAL]
 #


### PR DESCRIPTION
I'd like to use arduino-cmake to always be able to start a serial connection with my arduino from within vim by binding a key to :!make serial. It must have a constant name, so I've added the ability to define a target simply called "serial" with the option DEFAULT_SERIAL for TARGET_NAME, which is the same command as "${TARGET_NAME}-serial". No idea if this is a feature you'd like but I just threw it together and thought I'd contribute back. Thanks for the quality work by the way! It's allowed me to free myself of the Arduino IDE.
