### PR TITLE
Set SDK_PATH_HINTS to find the SDK better on windows.

### DIFF
--- a/cmake/ArduinoToolchain.cmake
+++ b/cmake/ArduinoToolchain.cmake
@@ -52,10 +52,16 @@ if(NOT ARDUINO_SDK_PATH)
         list(APPEND ARDUINO_PATHS arduino-00${VERSION})
     endforeach()
 
-    file(GLOB SDK_PATH_HINTS /usr/share/arduino*
-                             /opt/local/arduino*
-                             /opt/arduino*
-                             /usr/local/share/arduino*)
+    if(UNIX)
+        file(GLOB SDK_PATH_HINTS /usr/share/arduino*
+            /opt/local/arduino*
+            /opt/arduino*
+            /usr/local/share/arduino*)
+    elseif(WIN32)
+        set(SDK_PATH_HINTS "C:\\Program Files\\Arduino"
+            "C:\\Program Files (x86)\\Arduino"
+            )
+    endif()
     list(SORT SDK_PATH_HINTS)
     list(REVERSE SDK_PATH_HINTS)
 endif()


### PR DESCRIPTION
This change makes the module work for me on Windows7 with Arduino 1.0.5 and Visual Studio 2012 (for nmake).

I have problems with getting the sdk find the path on windows, trying to set it as input to Cmake, became an escape hell as "C:\Program Files (x86)\Arduino" had to many strange features in it for the environment. both spaces () and \ i think the \ could be swaped for / as cmake is quite smart. 
