### PR TITLE
Fixing problems with generate_avr_firmware and generate_avr_library

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -563,9 +563,9 @@ function(GENERATE_AVR_FIRMWARE INPUT_NAME)
         PROGRAMMER ${INPUT_PROGRAMMER}
         SERIAL ${INPUT_SERIAL}
         SRCS ${INPUT_SRCS}
-        HDRS ${INPUT_HDRS}
-        LIBS ${INPUT_LIBS}
-        AFLAGS ${INPUT_AFLAGS} )
+        ${INPUT_HDRS}
+        ${INPUT_LIBS}
+        ${INPUT_AFLAGS} )
     
 endfunction()
 

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -546,13 +546,13 @@ function(GENERATE_AVR_FIRMWARE INPUT_NAME)
     required_variables(VARS INPUT_BOARD INPUT_SRCS MSG "must define for target ${INPUT_NAME}")
 
     if(INPUT_HDRS)
-        set( INPUT_HDRS "SRCS ${INPUT_HDRS}" )
+        list(INSERT INPUT_HDRS 0 "HDRS")
     endif()
     if(INPUT_LIBS)
-        set( INPUT_LIBS "LIBS ${INPUT_LIBS}" )
+        list(INSERT INPUT_LIBS 0 "LIBS")
     endif()
     if(INPUT_AFLAGS)
-        set( INPUT_AFLAGS "AFLAGS ${INPUT_AFLAGS}" )
+        list(INSERT INPUT_AFLAGS 0 "AFLAGS")
     endif()
 
     generate_arduino_firmware( ${INPUT_NAME} 

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -563,9 +563,9 @@ function(GENERATE_AVR_FIRMWARE INPUT_NAME)
         PROGRAMMER ${INPUT_PROGRAMMER}
         SERIAL ${INPUT_SERIAL}
         SRCS ${INPUT_SRCS}
-        ${INPUT_HDRS}
-        ${INPUT_LIBS}
-        ${INPUT_AFLAGS} )
+        HDRS ${INPUT_HDRS}
+        LIBS ${INPUT_LIBS}
+        AFLAGS ${INPUT_AFLAGS} )
     
 endfunction()
 

--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -429,6 +429,14 @@ function(GENERATE_AVR_LIBRARY INPUT_NAME)
         set( INPUT_LIBS "LIBS ${INPUT_LIBS}" )
     endif()
 
+    if(INPUT_HDRS)
+        list(INSERT INPUT_HDRS 0 "HDRS")
+    endif()
+    if(INPUT_LIBS)
+        list(INSERT INPUT_LIBS 0 "LIBS")
+    endif()
+
+
     generate_arduino_library( ${INPUT_NAME} 
         NO_AUTOLIBS
         MANUAL


### PR DESCRIPTION
I had a problem with generate_avr_firmware when I needed to use the HDRS and AFLAGS options.
The content of these options got mangled into the SRCS option. 

After looking through the code I found out that the variables containing the HDRS, LIBS, AFLAGS option lists are concatenated wrong. So I changed the method to use list functions provided by cmake.
This helped me and the variables seem to be correct now.
