### PR TITLE
Fixed ARDUINO_AVRDUDE_CONFIG_PATH not found

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -2149,7 +2149,7 @@ if(NOT ARDUINO_FOUND AND ARDUINO_SDK_PATH)
 
     find_file(ARDUINO_AVRDUDE_CONFIG_PATH
         NAMES avrdude.conf
-        PATHS ${ARDUINO_SDK_PATH} /etc/avrdude
+        PATHS ${ARDUINO_SDK_PATH} /etc/avrdude /etc
         PATH_SUFFIXES hardware/tools
                       hardware/tools/avr/etc
         DOC "Path to avrdude programmer configuration file.")


### PR DESCRIPTION
Some distros put the avrdude.conf file directly in /etc.
