### PR TITLE
Fixed #99: updated ARDUINO_AVRDUDE_PROGRAM 's PATH_SUFFIXES 

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -2137,7 +2137,7 @@ if(NOT ARDUINO_FOUND AND ARDUINO_SDK_PATH)
     find_program(ARDUINO_AVRDUDE_PROGRAM
         NAMES avrdude
         PATHS ${ARDUINO_SDK_PATH}
-        PATH_SUFFIXES hardware/tools
+        PATH_SUFFIXES hardware/tools hardware/tools/avr/bin
         NO_DEFAULT_PATH)
 
     find_program(ARDUINO_AVRDUDE_PROGRAM


### PR DESCRIPTION
```
hardware/tools/avr/bin
```

is the correct path for Arduino's avrdude; if system avrdude is used, it won't be able to parse the Arduino SDK avrdude.conf file due to a version mismatch that breaks the config file format.
