### PR TITLE
Add path prefix for recent Arduino SDK for Mac

### DIFF
--- a/cmake/ArduinoToolchain.cmake
+++ b/cmake/ArduinoToolchain.cmake
@@ -70,6 +70,7 @@ find_path(ARDUINO_SDK_PATH
           NAMES lib/version.txt
           PATH_SUFFIXES share/arduino
                         Arduino.app/Contents/Resources/Java/
+                        Arduino.app/Contents/Java/
                         ${ARDUINO_PATHS}
           HINTS ${SDK_PATH_HINTS}
           DOC "Arduino SDK path.")


### PR DESCRIPTION
Hello,

I added one line for fix compatibility problem with recent SDK.

`ARDUINO_SDK_PATH` on Mac is different in SDK 1.5.7 or newer, since Mac app generation process has changed from [this commit](https://github.com/arduino/Arduino/commit/ab1ee51d68540d38310f186706feed4fde70b097).

Actually I had struggled with this problem half a day. I think this small change will help someone who is not familiar with cmake (like me until yesterday).
