### PR TITLE
Improved avrdude compatibility with windows drive names

### DIFF
--- a/cmake/Platform/Arduino.cmake
+++ b/cmake/Platform/Arduino.cmake
@@ -1174,10 +1174,10 @@ function(setup_arduino_bootloader_upload TARGET_NAME BOARD_ID PORT AVRDUDE_FLAGS
     endif()
     set(TARGET_PATH ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME})
 
-    list(APPEND AVRDUDE_ARGS "-Uflash:w:${TARGET_PATH}.hex")
-    list(APPEND AVRDUDE_ARGS "-Ueeprom:w:${TARGET_PATH}.eep:i")
+    list(APPEND AVRDUDE_ARGS '-Uflash:w:"${TARGET_PATH}.hex":i')
+    list(APPEND AVRDUDE_ARGS '-Ueeprom:w:"${TARGET_PATH}.eep":i')
     add_custom_target(${UPLOAD_TARGET}
-                     ${ARDUINO_AVRDUDE_PROGRAM} 
+                     ${ARDUINO_AVRDUDE_PROGRAM}
                      ${AVRDUDE_ARGS}
                      DEPENDS ${TARGET_NAME})
 
@@ -1222,7 +1222,7 @@ function(setup_arduino_programmer_burn TARGET_NAME BOARD_ID PROGRAMMER PORT AVRD
     endif()
     set(TARGET_PATH ${EXECUTABLE_OUTPUT_PATH}/${TARGET_NAME})
 
-    list(APPEND AVRDUDE_ARGS "-Uflash:w:${TARGET_PATH}.hex")
+    list(APPEND AVRDUDE_ARGS '-Uflash:w:"${TARGET_PATH}.hex"')
 
     add_custom_target(${PROGRAMMER_TARGET}
                      ${ARDUINO_AVRDUDE_PROGRAM} 
@@ -1284,7 +1284,7 @@ function(setup_arduino_bootloader_burn TARGET_NAME BOARD_ID PROGRAMMER PORT AVRD
         "-Ulfuse:w:${${BOARD_ID}.bootloader.low_fuses}:m")
 
     # Set bootloader image
-    list(APPEND AVRDUDE_ARGS "-Uflash:w:${${BOARD_ID}.bootloader.file}:i")
+    list(APPEND AVRDUDE_ARGS '-Uflash:w:"${${BOARD_ID}.bootloader.file}":i')
 
     # Set lockbits
     list(APPEND AVRDUDE_ARGS "-Ulock:w:${${BOARD_ID}.bootloader.lock_bits}:m")


### PR DESCRIPTION
Simple fix that adds double-quotes around avrdude file paths, improving compatibility with windows-style drive names that contain colons.
Previously any paths that contain a colon (eg. C:/) would cause an avrdude error.

Example:
`'-Uflash:w:${TARGET_PATH}.hex:i'` becomes `'-Uflash:w:"${TARGET_PATH}.hex":i'`
