### PR TITLE
Fixed typographical error, changed availabe to available in README.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -904,7 +904,7 @@ CMake configuration example::
 Linux Serial Terminals
 ~~~~~~~~~~~~~~~~~~~~~~
 
-On Linux a wide range on serial terminal are availabe. Here is a list of a couple:
+On Linux a wide range on serial terminal are available. Here is a list of a couple:
 
 * ``minicom``
 * ``picocom``


### PR DESCRIPTION
queezythegreat, I've corrected a typographical error in the documentation of the [arduino-cmake](https://github.com/queezythegreat/arduino-cmake) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
