### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -320,7 +320,7 @@ The options are:
 +--------------------+----------------------------------------------------------------------+------------------------------------+
 | **ARDLIBS**        | Manual list of Arduino type libraries, common use case is when the   |                                    |
 |                    | library header name does not match the librarie's directory name.    |                                    |
-|                    | **ADVANCED OPTION!** Can be used in conjuction with **NO_AUTOLIBS**. |                                    |
+|                    | **ADVANCED OPTION!** Can be used in conjunction with **NO_AUTOLIBS**. |                                    |
 +--------------------+----------------------------------------------------------------------+------------------------------------+
 | **AFLAGS**         | avrdude flags for target                                             |                                    |
 +--------------------+----------------------------------------------------------------------+------------------------------------+


### PR DESCRIPTION
@queezythegreat, I've corrected a typographical error in the documentation of the [arduino-cmake](https://github.com/queezythegreat/arduino-cmake) project. Specifically, I've changed conjuction to conjunction. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
